### PR TITLE
Pci dss

### DIFF
--- a/templates/standards/controls-mapping.json
+++ b/templates/standards/controls-mapping.json
@@ -61,6 +61,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-04", "GRM-06", "IAM-06", "IPY-01", "STA-03"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.3", "1.5", "2.3"]
         }
       ]
     },
@@ -144,6 +148,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-10", "GRM-04", "HRS-03", "HRS-09", "SEF-03"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.5"]
         }
       ]
     },
@@ -208,6 +216,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["GRM-04", "STA-04"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.5"]
         }
       ]
     },
@@ -247,6 +259,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-09", "GRM-02", "GRM-10"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.2"]
         }
       ]
     },
@@ -519,6 +535,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-10", "CCC-04", "GRM-06", "HRS-05", "HRS-08", "HRS-10", "HRS-11", "TVM-01", "MOS-02", "MOS-03", "MOS-05", "MOS-10", "MOS-11", "MOS-17", "MOS-20"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.3", "1.4", "1.5"]
         }
       ]
     },
@@ -859,6 +879,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IAM-02", "IAM-04", "IAM-06", "IAM-08", "IAM-09", "IAM-10", "IAM-12", "IAM-13"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.2"]
         }
       ]
     },
@@ -901,6 +925,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["HRS-08", "TVM-03", "MOS-17"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.3", "1.4", "1.5"]
         }
       ]
     },
@@ -914,6 +942,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-04", "IVS-12"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.1", "1.2"]
         }
       ]
     },
@@ -1024,6 +1056,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-07", "DCS-01", "DCS-03", "DCS-04", "GRM-04", "MOS-09", "MOS-18"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.4"]
         }
       ]
     },
@@ -1037,6 +1073,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["DCS-01", "GRM-04"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.4"]
         }
       ]
     },
@@ -1093,6 +1133,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["DSI-01", "DSI-03", "IPY-02", "IPY-03", "STA-01"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.3"]
         }
       ]
     },
@@ -1169,6 +1213,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-04", "EKM-03", "IVS-09", "IPY-03"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.6"]
         }
       ]
     },
@@ -1189,6 +1237,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-04", "EKM-03", "EKM-04"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.3"]
         }
       ]
     },
@@ -1211,6 +1263,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-04", "EKM-03", "EKM-04", "IVS-10", "IPY-04"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.3", "2.3"]
         }
       ]
     },
@@ -1419,6 +1475,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-02", "STA-08"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.4", "1.5"]
         }
       ]
     },
@@ -1453,6 +1513,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-01", "CCC-03", "MOS-07", "MOS-15"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.5", "2.2"]
         }
       ]
     },
@@ -1470,6 +1534,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-01", "IVS-06", "IPY-04"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.1", "2.1"]
         }
       ]
     },
@@ -1555,6 +1623,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-01", "CCC-03", "CCC-05"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.1"]
         }
       ]
     },
@@ -1574,6 +1646,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-01", "CCC-04", "MOS-15"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.2"]
         }
       ]
     },
@@ -1591,6 +1667,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-01", "IVS-02", "IVS-07", "TVM-02", "TVM-03"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.1", "2.2"]
         }
       ]
     },
@@ -1640,6 +1720,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IVS-06", "IVS-12"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.1", "1.2"]
         }
       ]
     },
@@ -1672,6 +1756,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IVS-06", "IVS-12", "IVS-13"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.1"]
         }
       ]
     },
@@ -1818,6 +1906,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-10", "HRS-08", "MOS-01", "MOS-02", "MOS-03", "MOS-04", "MOS-05", "MOS-06", "MOS-07", "MOS-08", "MOS-09", "MOS-10", "MOS-11", "MOS-12", "MOS-13"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["1.2", "1.4", "1.5", "2.4"]
         }
       ]
     },
@@ -2140,6 +2232,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["GRM-06", "STA-05", "STA-07"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["2.6"]
         }
       ]
     },

--- a/templates/standards/controls-mapping.json
+++ b/templates/standards/controls-mapping.json
@@ -1293,7 +1293,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["3.5"] //2.6?
+          "requirements": ["2.6", "3.5"]
         }
       ]
     },
@@ -2372,7 +2372,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": [] //2.6?
+          "requirements": ["2.6"]
         }
       ]
     },

--- a/templates/standards/controls-mapping.json
+++ b/templates/standards/controls-mapping.json
@@ -64,7 +64,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.3", "1.5", "2.3"]
+          "requirements": ["1.3", "1.5", "2.3", "6.3", "6.4", "6.7"]
         }
       ]
     },
@@ -151,7 +151,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.5"]
+          "requirements": ["2.5", "6.7"]
         }
       ]
     },
@@ -240,6 +240,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-09", "GRM-02", "GRM-04", "GRM-10", "GRM-11", "STA-06"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.4", "6.6"]
         }
       ]
     },
@@ -262,7 +266,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.2"]
+          "requirements": ["2.2", "6.1"]
         }
       ]
     },
@@ -349,7 +353,12 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AAC-01", "AAC-02", "GRM-01", "GRM-09"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["5.2"]
         }
+        
       ]
     },
     {
@@ -499,6 +508,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AAC-01", "IAM-01", "IAM-13"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.1", "6.6"]
         }
       ]
     },
@@ -538,7 +551,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.3", "1.4", "1.5"]
+          "requirements": ["1.3", "1.4", "1.5", "4.1", "5.1", "5.4"]
         }
       ]
     },
@@ -928,7 +941,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.3", "1.4", "1.5"]
+          "requirements": ["1.3", "1.4", "1.5", "5.3"]
         }
       ]
     },
@@ -1136,7 +1149,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.3"]
+          "requirements": ["2.3", "3.1"]
         }
       ]
     },
@@ -1216,7 +1229,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.6"]
+          "requirements": ["3.5"] //2.6?
         }
       ]
     },
@@ -1240,7 +1253,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.3"]
+          "requirements": ["2.3", "3.5"]
         }
       ]
     },
@@ -1266,7 +1279,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.3", "2.3"]
+          "requirements": ["1.3", "2.3", "3.5", "3.6", "4.1"]
         }
       ]
     },
@@ -1306,6 +1319,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["EKM-01", "EKM-02", "EKM-03"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["3.5", "3.6"]
         }
       ]
     },
@@ -1353,6 +1370,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-01", "CCC-05"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.4"]
         }
       ]
     },
@@ -1383,6 +1404,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-01", "AIS-03", "AIS-04", "CCC-01", "CCC-03", "DSI-02", "IAM-07", "STA-08"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["4.1", "6.2", "6.3", "6.5", "6.6", "6.7"]
         }
       ]
     },
@@ -1418,6 +1443,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IAM-02"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.3"]
         }
       ]
     },
@@ -1436,6 +1465,10 @@
         {
           "standard": "HITRUST CSF",
           "requirements": ["10.m"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.5"]
         }
       ]
     },
@@ -1478,7 +1511,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.4", "1.5"]
+          "requirements": ["1.4", "1.5", "6.3"]
         }
       ]
     },
@@ -1516,7 +1549,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.5", "2.2"]
+          "requirements": ["1.5", "2.2", "6.4"]
         }
       ]
     },
@@ -1589,6 +1622,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-01", "MOS-15", "MOS-19"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.2"]
         }
       ]
     },
@@ -1606,6 +1643,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["CCC-01", "CCC-05"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.4"]
         }
       ]
     },
@@ -1670,7 +1711,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.1", "2.2"]
+          "requirements": ["2.1", "2.2", "5.1", "6.2"]
         }
       ]
     },
@@ -1723,7 +1764,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.1", "1.2"]
+          "requirements": ["1.1", "1.2", "6.6"]
         }
       ]
     },
@@ -1779,6 +1820,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IVS-01", "TVM-01", "TVM-03", "MOS-17"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["5.1", "5.2", "5.3", "5.4"]
         }
       ]
     },
@@ -1833,6 +1878,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IVS-05", "SEF-02", "SEF-05", "TVM-02"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.1", "6.6"]
         }
       ]
     },
@@ -1854,6 +1903,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IVS-05", "SEF-02", "TVM-02"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["6.1", "6.5"]
         }
       ]
     },
@@ -1876,6 +1929,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["DSI-07", "DCS-05", "MOS-18"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["3.1"]
         }
       ]
     },
@@ -1909,7 +1966,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.2", "1.4", "1.5", "2.4"]
+          "requirements": ["1.2", "1.4", "1.5", "2.4", "5.3", "5.4", "6.2"]
         }
       ]
     },
@@ -2235,7 +2292,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.6"]
+          "requirements": [] //2.6?
         }
       ]
     },

--- a/templates/standards/controls-mapping.json
+++ b/templates/standards/controls-mapping.json
@@ -14,6 +14,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-01", "STA-03", "AAC-03"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["11.6", "12.1"]
         }
       ]
     },
@@ -129,6 +133,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-10", "GRM-03", "GRM-05", "HRS-07", "HRS-10", "SEF-03"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["8.1", "8.4", "12.1", "12.3", "12.4", "12.5"]
         }
       ]
     },
@@ -151,7 +159,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.5", "6.7"]
+          "requirements": ["2.5", "6.7", "8.4", "8.8", "10.9", "11.6", "12.4", "12.6"]
         }
       ]
     },
@@ -171,6 +179,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["HRS-09", "MOS-01", "MOS-05"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["12.6"]
         }
       ]
     },
@@ -219,7 +231,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.5"]
+          "requirements": ["2.5", "12.1"]
         }
       ]
     },
@@ -266,7 +278,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.2", "6.1"]
+          "requirements": ["2.2", "6.1", "12.2"]
         }
       ]
     },
@@ -287,6 +299,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["GRM-08", "GRM-11", "MOS-07"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["12.2"]
         }
       ]
     },
@@ -356,7 +372,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["5.2"]
+          "requirements": ["5.2", "8.1", "8.8", "10.1", "10.2", "10.3", "10.6", "10.9", "11.6"]
         }
         
       ]
@@ -379,6 +395,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["SEF-02"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["10.6", "11.5"]
         }
       ]
     },
@@ -455,6 +475,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AAC-01", "IVS-01", "IVS-03", "SEF-05"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["8.2", "10.1", "10.2", "10.3", "11.5"]
         }
       ]
     },
@@ -474,6 +498,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-04", "IAM-01", "IVS-01"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["10.5", "10.7"]
         }
       ]
     },
@@ -529,6 +557,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AAC-01"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["11.6"]
         }
       ]
     },
@@ -551,7 +583,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.3", "1.4", "1.5", "4.1", "5.1", "5.4"]
+          "requirements": ["1.3", "1.4", "1.5", "4.1", "5.1", "5.4", "9.5", "9.7", "12.3"]
         }
       ]
     },
@@ -571,6 +603,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["HRS-02"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["12.7"]
         }
       ]
     },
@@ -682,6 +718,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["AIS-04", "BCR-04", "GRM-04", "HRS-07", "HRS-11", "IAM-02", "IAM-04", "IAM-08", "IAM-12", "IVS-09", "IVS-11", "MOS-14"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["7.1", "8.2", "8.5"]
         }
       ]
     },
@@ -722,6 +762,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-04", "IAM-02", "IAM-12"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["8.3"]
         }
       ]
     },
@@ -766,6 +810,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-04", "IAM-02", "IAM-05", "IAM-06", "IAM-08", "IAM-12", "IVS-08", "IVS-11"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["8.1", "8.6"]
         }
       ]
     },
@@ -855,6 +903,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-04", "IAM-02", "IAM-09", "IAM-10", "IAM-11"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["7.2", "8.6", "8.8"]
         }
       ]
     },
@@ -919,6 +971,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IAM-02", "IAM-04", "IAM-10", "IAM-12"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["7.1", "8.8"]
         }
       ]
     },
@@ -979,6 +1035,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-04", "GRM-01", "IAM-02", "IAM-12", "MOS-16"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["8.2", "8.5"]
         }
       ]
     },
@@ -1050,6 +1110,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-06", "BCR-07", "DCS-02", "DCS-06", "DCS-07", "DCS-08", "DCS-09", "GRM-04", "HRS-01", "IAM-11"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["9.1", "9.2", "9.5"]
         }
       ]
     },
@@ -1072,7 +1136,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.4"]
+          "requirements": ["2.4", "9.5", "9.6", "9.7"]
         }
       ]
     },
@@ -1149,7 +1213,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.3", "3.1"]
+          "requirements": ["2.3", "3.1", "7.2"]
         }
       ]
     },
@@ -1495,6 +1559,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["IVS-05", "TVM-02"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["11.3"]
         }
       ]
     },
@@ -1511,7 +1579,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.4", "1.5", "6.3"]
+          "requirements": ["1.4", "1.5", "6.3", "12.7"]
         }
       ]
     },
@@ -1711,7 +1779,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["2.1", "2.2", "5.1", "6.2"]
+          "requirements": ["2.1", "2.2", "5.1", "6.2", "10.4"]
         }
       ]
     },
@@ -1800,7 +1868,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.1"]
+          "requirements": ["11.4"]
         }
       ]
     },
@@ -1881,7 +1949,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["6.1", "6.6"]
+          "requirements": ["6.1", "6.6", "11.2"]
         }
       ]
     },
@@ -1932,7 +2000,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["3.1"]
+          "requirements": ["3.1", "9.5", "9.6", "9.7", "9.8"]
         }
       ]
     },
@@ -1966,7 +2034,7 @@
         },
         {
           "standard": "PCI DSS",
-          "requirements": ["1.2", "1.4", "1.5", "2.4", "5.3", "5.4", "6.2"]
+          "requirements": ["1.2", "1.4", "1.5", "2.4", "5.3", "5.4", "6.2", "9.6"]
         }
       ]
     },
@@ -2100,6 +2168,10 @@
         {
           "standard": "HITRUST CSF",
           "requirements": ["11.a", "11.c"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["12.5"]
         }
       ]
     },
@@ -2119,6 +2191,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["SEF-02", "SEF-03", "SEF-05", "STA-04"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["12.5", "12.10"]
         }
       ]
     },
@@ -2138,6 +2214,10 @@
         {
           "standard": "CSA CCM",
           "requirements": ["BCR-01", "SEF-02", "SEF-04", "STA-02", "TVM-01"]
+        },
+        {
+          "standard": "PCI DSS",
+          "requirements": ["12.10"]
         }
       ]
     },


### PR DESCRIPTION
We still need 2.6, 3.2, 3.3, 3.4, 3.7, 4.2, 4.3, 7.3, 8.7, 9.2, 9.4, 9.9, 10.8(service providers only), 11.1, 12.8, 12.9(service providers only), 12.11(service providers only). Most of these are specific to cardholder policies so we'll most likely need to create a procedure document for it. 