### PR TITLE
Remove weblink fro iso-iec-27002-200

### DIFF
--- a/templates/standards/iso-iec-27002-2005.json
+++ b/templates/standards/iso-iec-27002-2005.json
@@ -1,7 +1,6 @@
 {
     "standard": "ISO/IEC 27002:2005",
     "version": "2005",
-    "webLink": "",
     "sections": [
       {
         "title": "5 - Security Policy",


### PR DESCRIPTION
This is causing an error w/ gql endpoint, weblink cannot be an empty string