### PR TITLE
Remove links to internal docs from procedures

### DIFF
--- a/templates/procedures/cp-ccm-config.md.tmpl
+++ b/templates/procedures/cp-ccm-config.md.tmpl
@@ -18,8 +18,8 @@
     * All systems are categorized and labeled by their corresponding
       environment, such as *dev*, *test*, and *prod*.
     * All systems are classified and labeled based on the data they store or
-      process, according to [{{companyShortName}} data classification
-      model](assets/data-classification-and-handling.pdf).
+      process, according to {{companyShortName}} data classification
+      model.
     * The Security team maintains automation which monitors all changes to IT
       assets, generates inventory lists, using automatic IT assets discovery,
       and services provided by each cloud provider.

--- a/templates/procedures/cp-ir-process.md.tmpl
+++ b/templates/procedures/cp-ir-process.md.tmpl
@@ -2,8 +2,7 @@
 
 The {{companyShortName}} incident response process follows the process recommended by
 [SANS](https://www.sans.org), an industry leader in security. Process flows are
-a direct representation of the SANS process which can be found in [this
-document](sections/incident-flowchart.pdf).
+a direct representation of the SANS process.
 
 {{companyShortName}}'s incident response classifies security-related events into the
 following categories:

--- a/templates/procedures/cp-sanctions.md.tmpl
+++ b/templates/procedures/cp-sanctions.md.tmpl
@@ -59,5 +59,3 @@ other retaliatory action as a consequence.
    individual sanctioned, 2) the reason for the sanction, and 3) specific
    procedures for service or account restriction / revocation or other
    disciplinary actions as required.
-
-[Warning Notice Template](ref/sanction-notice.pdf)

--- a/templates/procedures/cp-sanctions.md.tmpl
+++ b/templates/procedures/cp-sanctions.md.tmpl
@@ -59,3 +59,5 @@ other retaliatory action as a consequence.
    individual sanctioned, 2) the reason for the sanction, and 3) specific
    procedures for service or account restriction / revocation or other
    disciplinary actions as required.
+   
+   [Warning Notice Template](https://github.com/JupiterOne/security-policy-templates/raw/master/templates/ref/sanction-notice.pdf)


### PR DESCRIPTION
Modifying three procedures that had a reference to an internal .pdf - the link in cp-ir-process.md.tmpl was specifically mentioned by a customer.