### PR TITLE
Updated links to direct to correct procedure instead of 404

### DIFF
--- a/templates/policies/data-mgmt.md.tmpl
+++ b/templates/policies/data-mgmt.md.tmpl
@@ -21,7 +21,7 @@ data remains available when it needed and in case of a disaster.
 {{companyShortName}} policy requires that
 
 (a) Data should be classified at time of creation or acquisition according to
-the [{{companyShortName}} data classification model](data-mgmt.md#data-classification-model),
+the [{{companyShortName}} data classification model](data-mgmt.md#cp-data-classification),
 by labeling or tagging the data.
 
 (b) Maintain an up-to-date inventory and data flows mapping of all critical

--- a/templates/procedures/cp-sdlc-hipaa.md.tmpl
+++ b/templates/procedures/cp-sdlc-hipaa.md.tmpl
@@ -60,10 +60,10 @@ breach notification, should a breach occurs that impact their PHI.
 
 Follow the requirements listed in the following documents:
 
-- [Data Classification Model](data-mgmt.md#data-classification-model);
-- [Data Handling Requirements](data-mgmt.md#data-handling-requirements-matrix);
+- [Data Classification Model](data-mgmt.md#cp-data-classification);
+- [Data Handling Requirements](data-mgmt.md#cp-data-handling);
 - [Data Protection Policy and Procedures](data-protection.md); and
-- [Backup and Recovery Process](data-mgmt.md#backup-and-recovery).
+- [Backup and Recovery Process](data-mgmt.md#cp-data-backup).
 
 #### Risk Analysis and Compliance Assessment
 

--- a/templates/ref/employee-handbook.md.tmpl
+++ b/templates/ref/employee-handbook.md.tmpl
@@ -64,7 +64,7 @@ complete the following security training:
 
     - [Roles, Responsibilities and Training](rar.md)
     - [HR and Personnel Security](hr.md)
-    - [Data Classification and Handling](data-mgmt.md#data-classification-model)
+    - [Data Classification and Handling](data-mgmt.md#cp-data-classification)
 
 {{#needStandardHIPAA}}
 * **HIPAA awareness** training


### PR DESCRIPTION
The links in a few spots across procedure, policies, and refs were linking to a non-existing procedure. 